### PR TITLE
Migrate CrossAssets to CrossAssetMonitor plugin

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,86 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-gray-800/50 data-[state=selected]:bg-gray-800",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-gray-400 [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+export {
+  Table,
+  TableHeader,
+  TableHead,
+  TableBody,
+  TableRow,
+  TableCell,
+}

--- a/src/config/pluginRegistry.ts
+++ b/src/config/pluginRegistry.ts
@@ -3,7 +3,6 @@ import { NewsFeed } from '@/plugins/NewsFeed';
 import { CrossAssetMonitor } from '@/plugins/CrossAssetMonitor';
 import { HistoricalChart } from '@/plugins/HistoricalChart';
 import { IntradayChart } from '@/plugins/IntradayChart';
-import { CurrencyExchangeRate } from '@/plugins/CurrencyExchangeRate';
 
 // Define a type for better safety (optional but recommended)
 export type PluginComponentType = React.ComponentType<any>; // Use specific props type if needed
@@ -26,10 +25,6 @@ export const pluginRegistry: Record<string, PluginConfig> = {
     'crossAsset': {
         id: 'crossAsset',
         component: CrossAssetMonitor,
-    },
-    'currencyExchange': { // <-- Add the new plugin entry
-        id: 'currencyExchange',
-        component: CurrencyExchangeRate,
     },
     'history': {
         id: 'history',

--- a/src/services/pluginService.ts
+++ b/src/services/pluginService.ts
@@ -19,7 +19,7 @@ export const getActivePlugins = async (): Promise<ActivePluginInfo[]> => {
 
     // For this PoC, return a hardcoded list of plugin IDs
     // You can change this array to test loading different plugins
-    const activePluginIds: string[] = ['news', 'currencyExchange', 'history', 'intraday'];
+    const activePluginIds: string[] = ['news', 'crossAssetMonitor', 'history', 'intraday'];
     // const activePluginIds: string[] = ['news', 'intraday']; // Example: load only two
 
     console.log("Received active plugins:", activePluginIds);


### PR DESCRIPTION
This PR migrates the CrossAssets functionality from airrun-dojo-dashboard to a new CrossAssetMonitor plugin in finance-dashboard-demo.

Changes include:
- Created new shadcn/ui table component for consistent styling
- Implemented CrossAssetMonitor plugin with mock data
- Replaced CurrencyExchangeRate plugin with CrossAssetMonitor in registry and service
- Used the same layout and styling patterns as other plugins

The new CrossAssetMonitor displays financial indices data in a table format using the shadcn/ui components for consistent styling across the application.